### PR TITLE
Revert renaming Cycle to Sprint

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -6,8 +6,8 @@
 </div>
 
   <ul>
-    <li>Current Sprint: <a href="https://github.com/opencollective/opencollective/issues/5666">2022 Q2 cycle 2</a></li>
-    <li>Ideas for Next Cycle: <a href="https://github.com/opencollective/opencollective/discussions/5741">2022 Q3 cycle 2</a></li>
-    <li><a href="https://github.com/orgs/opencollective/projects/5">Cycle Planning & Weekly Board</a></li>
+    <li>Current Sprint: <a href="https://github.com/opencollective/opencollective/issues/5666">2022 Q2 Sprint 2</a></li>
+    <li>Ideas for Next Sprint: <a href="https://github.com/opencollective/opencollective/discussions/5741">2022 Q3 Sprint 2</a></li>
+    <li><a href="https://github.com/orgs/opencollective/projects/5">Sprint Planning & Weekly Board</a></li>
     <li><a href="https://github.com/opencollective/opencollective/issues">Issues Repository</a></li>
   </ul>


### PR DESCRIPTION
I'm not aware of any formal decision there and I would like to see this idea pitched and agreed.

This is a word that we're using multiple times per day and that is confusing to do changes in this way.